### PR TITLE
Added JSDoc build system. Added docstrings to legion.js and legion/game.js.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/**
 **.log
 coverage*
 src_instrumented
+docs/**

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,31 @@
+{
+    "source": {
+        "include": [
+            "./src/"
+        ],
+        "exclude": [],
+        "includePattern": ".+\\.js(doc)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "opts": {
+        "destination": "./docs/",
+        "encoding"   : "utf8",
+        "lenient"    : true,
+        "private"    : true,
+        "recurse"    : true,
+        "template"   : "templates/default",
+        "tutorials"  : "./docs/tutorials"
+    },
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "markdown": {
+        "parser"  : "gfm",
+        "hardwrap": true
+    },
+    "plugins": [
+        "plugins/markdown"
+    ],
+    "templates": {}
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "file": "^0.2.2",
     "istanbul": "^0.3.6",
     "jscs": "^1.11.3",
+    "jsdoc": "^3.3.2",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",
     "mocha-phantomjs": "git://github.com/docmarionum1/mocha-phantomjs.git",

--- a/src/legion.js
+++ b/src/legion.js
@@ -13,7 +13,10 @@ if (!isNode) {
   window.global = window;
 }
 
-// Create legion global
+/**
+ * Create legion global
+ * @global
+ */
 global.legion = {
   isNode: isNode,
   renderer: null,

--- a/src/legion/environment.js
+++ b/src/legion/environment.js
@@ -12,6 +12,9 @@ define(['legion/class'], function(Class) {
     // Array of entities in the environment, default []
     entities: null,
 
+    // Render view background color, default 0x000000
+    backgroundColor: 0x000000,
+
     /*
       init()
 
@@ -76,10 +79,9 @@ define(['legion/class'], function(Class) {
         properties = typeof properties !== 'undefined' ? properties : {};
         this.parent(properties);
 
-        var backgroundColor = 'backgroundColor' in properties ?
-          properties.backgroundColor : 0x000000;
-
-        this.stage = new PIXI.Stage(backgroundColor);
+        this.stage = new PIXI.Stage(
+          properties.backgroundColor || this.backgroundColor
+        );
       },
 
       /*

--- a/src/legion/environment.js
+++ b/src/legion/environment.js
@@ -79,9 +79,7 @@ define(['legion/class'], function(Class) {
         properties = typeof properties !== 'undefined' ? properties : {};
         this.parent(properties);
 
-        this.stage = new PIXI.Stage(
-          properties.backgroundColor || this.backgroundColor
-        );
+        this.stage = new PIXI.Stage(this.backgroundColor);
       },
 
       /*

--- a/src/legion/game.js
+++ b/src/legion/game.js
@@ -1,45 +1,89 @@
 'use strict';
 
+/**
+ * @module legion/game
+ */
 define([
     'legion/class', 'legion/timer', 'legion/event',
     'legion/input', 'legion/util'
 ], function(Class, Timer, Event, Input, Util) {
+  /**
+   * Creates a new Game.
+   * @class Game
+   * @extends module:legion/Class
+   */
   var Game = Class.extend({
 
-    // The target FPS
+    /**
+     * The target FPS
+     * @type {Number}
+     * @default 60
+     */
     fps: 60,
 
-    // The current game time
+    /**
+     * The current game time
+     * @type {Date}
+     */
     clock: null,
 
-    // Whether the game is paused
+    /**
+     * Whether the game is paused
+     * @type {Boolean}
+     * @default false
+     */
     paused: false,
 
-    // The list of timers in the game
+    /**
+     * The list of timers in the game
+     * @type {Array.<Timer>}
+     * @private
+     */
     _timers: null,
 
-    // frame times
+    /**
+     * frame times
+     * @type {Array.<Number>}
+     * @private
+     */
     _frameTimes: null,
 
-    // Whether it's a multiplayer game
+    /**
+     * Whether it's a multiplayer game
+     * @type {Boolean}
+     * @default false
+     */
     multiplayer: false,
 
-    // Available server-side in multiplayer games
+    /**
+     * Available server-side in multiplayer games
+     * @type {io}
+     */
     io: null,
 
-    // Available client-side in multiplayer games
+    /**
+     * Available client-side in multiplayer games
+     * @type {socket}
+     */
     socket: null,
 
-    // Current environment for the game
+    /**
+     * Current environment for the game
+     * @type {Environment}
+     */
     environment: null,
 
-    // A sequential object ID to uniquely identify all objects.
+    /**
+     * A sequential object ID to uniquely identify all objects.
+     * @type {Number}
+     */
     objectID: 0,
 
-    /*
-      init({fps: 60})
-
-      @param {object} properties
+   /**
+    * Initialize the Game class.
+    * @method
+    * @param  {Object} properties - Class initialization properties
+    * @return {undefined}
     */
     init: function(properties) {
       this.parent(properties);
@@ -62,6 +106,11 @@ define([
       }
     },
 
+    /**
+     * Initialize the client.
+     * @method
+     * @return {undefined}
+     */
     initClient: function() {
       if (this.multiplayer) {
         this.socket.on('connect', Util.hitch(this, this.onConnectionClient));
@@ -72,36 +121,57 @@ define([
       }
     },
 
+    /**
+     * Initialize the server.
+     * @method
+     * @return {undefined}
+     */
     initServer: function() {
       this.io.on('connection', Util.hitch(this, this.onConnectionServer));
     },
 
-    /*
-      Called on the server-side when a client connects.
-    */
+    /**
+     * Called on the server-side when a client connects.
+     * @method
+     * @param  {Socket} socket - socket
+     * @return {undefined}
+     */
     onConnectionServer: function(socket) {
       console.log('player connected!');
       socket.emit('connect');
     },
 
-    /*
-      Called on the client-side when the server responds to the client's
-      connection.  Triggered by having the server's socket emit 'connect'.
-    */
+    /**
+     * Called on the client-side when the server responds to the client's
+     * connection. Triggered by having the server's socket emit 'connect'.
+     * @method
+     * @return {undefined}
+     */
     onConnectionClient: function() {
       console.log('connected to server');
     },
 
+    /**
+     * [syncClient description]
+     * @method
+     * @return {undefined}
+     */
     syncClient: function() {
     },
 
+    /**
+     * [syncServer description]
+     * @method
+     * @return {undefined}
+     */
     syncServer: function() {
       this.io.emit('sync', {clock: this.clock});
     },
 
-    /*
-      loop() is the main game loop.
-    */
+    /**
+     * The main game loop.
+     * @return {undefined}
+     */
     loop: function() {
       var newClock = (new Date()).getTime();
       this.delta = newClock - this.clock;
@@ -126,6 +196,13 @@ define([
       }
     },
 
+    /**
+     * [_measureFPS description]
+     * @method
+     * @private
+     * @param  {Number} newTime - The time in milliseconds
+     * @return {undefined}
+     */
     _measureFPS: function(newTime) {
       if (this._frameTimes.length >= this.fps) {
         this._frameTimes.shift();
@@ -136,24 +213,23 @@ define([
     },
 
 
-    /*
-      _update() is called once each frame to the current environment.
-    */
+    /**
+     * Called once each frame to the current environment.
+     * @return {undefined}
+     */
     _update: function() {
       if (this.environment) {
         this.environment._update();
       }
     },
 
-
-    /*
-      createTimer() creates and returns a timer for the given milliseconds.
-
-      Takes an object with:
-        target: The target time in milliseconds
-        loop: Whether to automatically loop the timer.
-
-      @param {int} milliseconds
+   /**
+    * Creates and returns a timer for the given milliseconds.
+    * @method
+    * @param  {Object} properties - New timer properties
+    * @param  {Number} properties.target - The target time in milliseconds
+    * @param  {Number} properties.loop - Whether to automatically loop the timer
+    * @return {Timer} A timer for the specified milliseconds
     */
     createTimer: function(properties) {
       var timer = new Timer(properties);
@@ -162,20 +238,33 @@ define([
     },
 
 
-    /*
-      _updateTimers() updates all the timers in this.timers
-    */
+    /**
+     * Updates all the timers in this.timers
+     * @method
+     * @private
+     * @param  {Number} delta - The time difference in milliseconds
+     * @return {undefined}
+     */
     _updateTimers: function(delta) {
       for (var i = 0; i < this._timers.length; i++) {
         this._timers[i].tick(delta);
       }
     },
 
+    /**
+     * Sets the environment
+     * @param  {Environment} environment - The environment to set to
+     * @return {undefined}
+     */
     setEnvironment: function(environment) {
       this.environment = environment;
       this.environment._bindGame(this);
     },
 
+    /**
+     * Gets the objectID
+     * @return {Number} The objectID incremented by 1
+     */
     _getObjectID: function() {
       return this.objectID++;
     }


### PR DESCRIPTION
This pull request addresses issue #63, and an extraneous minor refactoring from long ago.

As per the initial requirements, a JSDoc build system has been put in place. Docstrings has been added to `legion.js` and `legion/game.js`. Documentations will be exported to the `./docs/` directory Tutorials has been configured to export into `./docs/tutorials/` directory. I specifically used these files as they seemed to have a sizable variation of items to docstring.

**Please review the docstrings for accuracy before accepting this pull request.** There are some items I am unsure about how to docstring it, such as what datatype some properties are or what the intended purpose (description) of some methods are, etc..

**Requirements:**
1. Run `npm install` to install the newly added JSDoc module.
2. Create a `./docs/` and `./docs/tutorials` directory.
3. Run `node node_modules/jsdoc/jsdoc.js -c ./jsdoc.conf.json` to generate the documentation.
4. Open `./docs/index.html` to view the document index page. The documentation should have navigation links to other pages based on what was defined in the docstrings.

_If rebuilding the documentation, you may want to clean the `./docs/` and `./docs/tutorials/` directories beforehand as JSDoc will not clean it for you. If not. It may also be in the best interest to write a script for this._

From my experience, I believe docstrings would best be placed at:
- global namespaces
- module level
- classes
- properties of classes
- methods of classes
- functions

I am currently using the default built-in JSDoc3 template. JSDoc documentation style can be modified using templates. One important thing to note is that although the code is fully documented via docstrings, it is the template that will dictate how the items will look when the documentation is generated. Some templates organizes classes differently, others will not display certain items unless the item belongs in a namespace, etc.
